### PR TITLE
fix: missing headers for some requests

### DIFF
--- a/src/postgrest-client.ts
+++ b/src/postgrest-client.ts
@@ -379,6 +379,7 @@ export class PostgrestClient<DB extends BaseDB | never> {
 
         return {
           ...response,
+          headers,
           data: response.rows,
           status,
           statusText,
@@ -513,6 +514,7 @@ export class PostgrestClient<DB extends BaseDB | never> {
 
         return {
           ...response,
+          headers,
           data: response.rows,
           status,
           statusText,

--- a/test/postgrest-client.test.ts
+++ b/test/postgrest-client.test.ts
@@ -4,7 +4,16 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import axios from 'axios';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { assert, Equals } from 'tsafe';
 
 import {
@@ -1949,6 +1958,419 @@ describe('special characters', () => {
         });
 
         expect(eqQueryRes.totalLength).toBe(1);
+      });
+    });
+  });
+});
+
+describe('response object', () => {
+  describe.each([
+    ['fetch', undefined],
+    ['axios', axios.create()],
+  ])('%s', (_name, axiosInstance) => {
+    const pgClient = new PostgrestClient<DB>({ base: BASE_URL, axiosInstance });
+
+    describe('get', () => {
+      it('default', async () => {
+        const { headers, rows, status, statusText } = await pgClient.get({
+          query: pgClient.query('actors'),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with pagination', async () => {
+        const { headers, rows, status, statusText, pagesLength, totalLength } =
+          await pgClient.get({
+            query: pgClient.query('actors').count('exact'),
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(pagesLength).toBeTypeOf('number');
+        expect(totalLength).toBeTypeOf('number');
+      });
+
+      it('single', async () => {
+        const { headers, row, status, statusText } = await pgClient.get({
+          query: pgClient.query('actors').eq('id', 1).single(),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(row).toBeTypeOf('object');
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+    });
+
+    describe('head', async () => {
+      it('default', async () => {
+        const { headers, status, statusText } = await pgClient.head({
+          query: pgClient.query('actors'),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with pagination', async () => {
+        const { headers, status, statusText, pagesLength, totalLength } =
+          await pgClient.head({
+            query: pgClient.query('actors').count('exact'),
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(pagesLength).toBeTypeOf('number');
+        expect(totalLength).toBeTypeOf('number');
+      });
+
+      it('single', async () => {
+        const { headers, status, statusText } = await pgClient.head({
+          query: pgClient.query('actors').eq('id', 1).single(),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+    });
+
+    describe('post', () => {
+      afterEach(async () => {
+        await pgClient.delete({
+          query: pgClient
+            .query('actors')
+            .eq('first_name', 'Peter')
+            .eq('last_name', 'Sellers'),
+        });
+      });
+
+      it('default', async () => {
+        const { headers, status, statusText } = await pgClient.post({
+          query: pgClient.query('actors'),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with return', async () => {
+        const { headers, status, statusText, rows } = await pgClient.post({
+          query: pgClient.query('actors').returning('representation'),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with single return', async () => {
+        const { headers, status, statusText, row } = await pgClient.post({
+          query: pgClient.query('actors').returning('representation').single(),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+      });
+
+      it('with pagination', async () => {
+        const { headers, status, statusText, rows, totalLength } =
+          await pgClient.post({
+            query: pgClient
+              .query('actors')
+              .returning('representation')
+              .count('exact'),
+            data: { first_name: 'Peter', last_name: 'Sellers' },
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).instanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(totalLength).toBeTypeOf('number');
+      });
+
+      it('with single return and pagination', async () => {
+        const { headers, status, statusText, row, totalLength } =
+          await pgClient.post({
+            query: pgClient
+              .query('actors')
+              .returning('representation')
+              .count('exact')
+              .single(),
+            data: { first_name: 'Peter', last_name: 'Sellers' },
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+        expect(totalLength).toBeTypeOf('number');
+      });
+    });
+
+    describe('patch', async () => {
+      let actor: DB['actors']['get'];
+
+      beforeEach(async () => {
+        const { row } = await pgClient.post({
+          query: pgClient.query('actors').returning('representation').single(),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        actor = row;
+      });
+
+      afterEach(async () => {
+        await pgClient.delete({
+          query: pgClient.query('actors').eq('id', actor.id),
+        });
+      });
+
+      it('default', async () => {
+        const { headers, status, statusText } = await pgClient.patch({
+          query: pgClient.query('actors').eq('id', actor.id),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with return', async () => {
+        const { headers, status, statusText, rows } = await pgClient.patch({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation'),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with single return', async () => {
+        const { headers, status, statusText, row } = await pgClient.patch({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation')
+            .single(),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+      });
+
+      it('with pagination', async () => {
+        const { headers, status, statusText, rows, totalLength } =
+          await pgClient.patch({
+            query: pgClient
+              .query('actors')
+              .eq('id', actor.id)
+              .returning('representation')
+              .count('exact'),
+            data: { first_name: 'Peter', last_name: 'Sellers' },
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).instanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(totalLength).toBeTypeOf('number');
+      });
+
+      it('with single return and pagination', async () => {
+        const { headers, status, statusText, row, totalLength } =
+          await pgClient.patch({
+            query: pgClient
+              .query('actors')
+              .eq('id', actor.id)
+              .returning('representation')
+              .count('exact')
+              .single(),
+            data: { first_name: 'Peter', last_name: 'Sellers' },
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+        expect(totalLength).toBeTypeOf('number');
+      });
+    });
+
+    describe('put', async () => {
+      let actor: DB['actors']['get'];
+
+      beforeEach(async () => {
+        const { row } = await pgClient.post({
+          query: pgClient.query('actors').returning('representation').single(),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        actor = row;
+      });
+
+      afterEach(async () => {
+        await pgClient.delete({
+          query: pgClient.query('actors').eq('id', actor.id),
+        });
+      });
+
+      it('default', async () => {
+        const { headers, status, statusText } = await pgClient.put({
+          query: pgClient.query('actors').eq('id', actor.id),
+          data: { first_name: 'Peter', last_name: 'Sellers', id: actor.id },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with return', async () => {
+        const { headers, status, statusText, rows } = await pgClient.put({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation'),
+          data: { first_name: 'Peter', last_name: 'Sellers', id: actor.id },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with single return', async () => {
+        const { headers, status, statusText, row } = await pgClient.put({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation')
+            .single(),
+          data: { first_name: 'Peter', last_name: 'Sellers', id: actor.id },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+      });
+
+      it('with pagination', async () => {
+        const { headers, status, statusText, rows } = await pgClient.put({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation')
+            .count('exact'),
+          data: { first_name: 'Peter', last_name: 'Sellers', id: actor.id },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).instanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with single return and pagination', async () => {
+        const { headers, status, statusText, row } = await pgClient.put({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation')
+            .count('exact')
+            .single(),
+          data: { first_name: 'Peter', last_name: 'Sellers', id: actor.id },
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+      });
+    });
+
+    describe('delete', async () => {
+      let actor: DB['actors']['get'];
+
+      beforeEach(async () => {
+        const { row } = await pgClient.post({
+          query: pgClient.query('actors').returning('representation').single(),
+          data: { first_name: 'Peter', last_name: 'Sellers' },
+        });
+        actor = row;
+      });
+
+      it('default', async () => {
+        const { headers, status, statusText } = await pgClient.delete({
+          query: pgClient.query('actors').eq('id', actor.id),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with return', async () => {
+        const { headers, status, statusText, rows } = await pgClient.delete({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation'),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).toBeInstanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+      });
+
+      it('with single return', async () => {
+        const { headers, status, statusText, row } = await pgClient.delete({
+          query: pgClient
+            .query('actors')
+            .eq('id', actor.id)
+            .returning('representation')
+            .single(),
+        });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+      });
+
+      it('with pagination', async () => {
+        const { headers, status, statusText, rows, totalLength } =
+          await pgClient.delete({
+            query: pgClient
+              .query('actors')
+              .eq('id', actor.id)
+              .returning('representation')
+              .count('exact'),
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(rows).instanceOf(Array);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(totalLength).toBeTypeOf('number');
+      });
+
+      it('with single return and pagination', async () => {
+        const { headers, status, statusText, row, totalLength } =
+          await pgClient.delete({
+            query: pgClient
+              .query('actors')
+              .eq('id', actor.id)
+              .returning('representation')
+              .count('exact')
+              .single(),
+          });
+        expect(headers).toBeInstanceOf(Headers);
+        expect(status).toBeTypeOf('number');
+        expect(statusText).toBeTypeOf('string');
+        expect(row).toBeTypeOf('object');
+        expect(totalLength).toBeTypeOf('number');
       });
     });
   });


### PR DESCRIPTION
Some responses were missing `headers` property (it was `undefined`).
Responses are now covered with tests to make sure this won't happen again.