### PR TITLE
build: .npmignore updated to make the package smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,8 @@ vite.config.ts
 .eslintignore
 .eslintrc
 compose.yml
+.github
+.husky
+# docs might be nice to have,
+# but it's large and node_modules size grows very quickly
+docs


### PR DESCRIPTION
Added some folders to `.npmignore` to avoid packaging unnecessary files and therefore making the package much larger than needed.