### PR TITLE
fix: allow capital letters in json selectors

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,7 @@ export type Headers = {
 
 export type HeaderModifiers = Pick<Headers, 'count' | 'returning'>;
 
-type Character =
+type Letter =
   | 'a'
   | 'b'
   | 'c'
@@ -143,8 +143,8 @@ export type CompositeFilter<
   DB extends BaseDB,
   TableName extends keyof DB,
 > = `${Extract<keyof DB[TableName]['get'], string>}->${
-  | Character
-  | Capitalize<Character>}${string}`;
+  | Letter
+  | Capitalize<Letter>}${string}`;
 export type CompositeFilterWithModifier<
   DB extends BaseDB,
   TableName extends keyof DB,

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,9 @@ export type VerticalColumnFilter<
 export type CompositeFilter<
   DB extends BaseDB,
   TableName extends keyof DB,
-> = `${Extract<keyof DB[TableName]['get'], string>}->${Character}${string}`;
+> = `${Extract<keyof DB[TableName]['get'], string>}->${
+  | Character
+  | Capitalize<Character>}${string}`;
 export type CompositeFilterWithModifier<
   DB extends BaseDB,
   TableName extends keyof DB,

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -297,6 +297,9 @@ describe('Query', () => {
         expect(
           query[method]('json_column2->val', 1).toString({ encoded: false }),
         ).toBe(`json_column2->val=${method}.1`);
+        expect(
+          query[method]('json_column2->VAL', 1).toString({ encoded: false }),
+        ).toBe(`json_column2->VAL=${method}.1`);
 
         expect(
           query[method]('json_column->val1', 1)


### PR DESCRIPTION
Selectors like `json_column2->VAL` were flagged by TypeScript as errors because we were not accepting capital letters after the arrow `->`

Note that it might be difficult to verify this fix since we don't have type linting set up. The best way might be from VSCode.