### PR TITLE
feat: top level filter (!inner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The PostgREST Client is a type-safe TypeScript client designed for use with Post
   - ✅ Foreign key joins on write
   - ✅ Nested embedding
   - ✅ Embedded filtering
-  - ⬜ Top-level filtering
+  - ✅ Top-level filtering
   - ⬜ Null filtering
   - ✅ Empty embedded
   - ✅ Embedded ordering

--- a/src/query.ts
+++ b/src/query.ts
@@ -214,7 +214,7 @@ export class Query<
   }
 
   /**
-   * Sets boolean value marking this as a tope level filter.
+   * Sets boolean value marking this as a top level filter.
    * And adds `!inner` to the query constructed.
    *
    * This is used only in embedded queries and will throw an error otherwise.

--- a/src/query.ts
+++ b/src/query.ts
@@ -217,7 +217,7 @@ export class Query<
    * Sets boolean value marking this as a tope level filter.
    * And adds `!inner` to the query constructed.
    *
-   * This is used only in embedded queries and will be ignored otherwise.
+   * This is used only in embedded queries and will throw an error otherwise.
    *
    * @see https://postgrest.org/en/v12/references/api/resource_embedding.html#top-level-filtering
    *
@@ -723,6 +723,10 @@ export class Query<
       return `${renamePrefix}${this.#props.tableName}${inner}(${selectStr})`;
     }
 
+    if (this.#props.inner && !isNested) {
+      throw new Error('.inner() can be used only on embedded queries');
+    }
+
     return selectStr;
   }
 
@@ -976,6 +980,9 @@ export class Query<
    *
    * @param options optional object `{ encoded?: boolean }`
    * @returns Query string (URL encoded by default).
+   *
+   * @throws {Error}
+   * Throws when top level filtering for top level query (non-embedded) is detected.
    */
   toString({
     encoded = true,

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1383,15 +1383,22 @@ describe('Query', () => {
         );
       });
 
-      it('top level filtering (!inner)', () => {
-        const query = q1.select(['*', q2.select('*').eq('id', 1).inner()]);
-        expect(query.toObject()).toMatchObject({
-          tableName: 'test_table',
-          select: ['*', { tableName: 'test_table2', eq: [['id', 1, false]] }],
+      describe('top level filtering (!inner)', () => {
+        it('simple', () => {
+          const query = q1.select(['*', q2.select('*').eq('id', 1).inner()]);
+          expect(query.toObject()).toMatchObject({
+            tableName: 'test_table',
+            select: ['*', { tableName: 'test_table2', eq: [['id', 1, false]] }],
+          });
+          expect(query.toString({ encoded: false })).toBe(
+            'select=*,test_table2!inner(*)&test_table2.id=eq.1',
+          );
         });
-        expect(query.toString({ encoded: false })).toBe(
-          'select=*,test_table2!inner(*)&test_table2.id=eq.1',
-        );
+
+        it('throws on non-embedded query', () => {
+          const query = q1.select('*').inner();
+          expect(() => query.toString()).toThrowError();
+        });
       });
 
       // https://postgrest.org/en/stable/references/api/resource_embedding.html#null-filtering-on-embedded-resources

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1383,9 +1383,8 @@ describe('Query', () => {
         );
       });
 
-      it.todo('top level filtering (!inner)', () => {
-        // TODO: needs a way to tell it to do top level filtering
-        const query = q1.select(['*', q2.select('*').eq('id', 1)]);
+      it('top level filtering (!inner)', () => {
+        const query = q1.select(['*', q2.select('*').eq('id', 1).inner()]);
         expect(query.toObject()).toMatchObject({
           tableName: 'test_table',
           select: ['*', { tableName: 'test_table2', eq: [['id', 1, false]] }],


### PR DESCRIPTION
Support for top level filtering (`!inner` keyword)
https://postgrest.org/en/v12/references/api/resource_embedding.html#top-level-filtering

This is adding `.inner()` method to the query class. In case it's used on root query it will throw an error later in `toString()`, and if called in embedded query it will set `!inner` keyword in the constructed query string.

Documentation will be updated later after releasing this.