### PR TITLE
feat: top level ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The PostgREST Client is a type-safe TypeScript client designed for use with Post
   - ⬜ Null filtering
   - ✅ Empty embedded
   - ✅ Embedded ordering
-  - ⬜ Top-level ordering
+  - ✅ Top-level ordering
   - ⬜ Spread embedded resources
 - 🔳 Resource representation
   - ✅ Singular or plural

--- a/test/postgrest-client.test.ts
+++ b/test/postgrest-client.test.ts
@@ -737,12 +737,8 @@ describe('Postgrest Client', () => {
               query: pgClient
                 .query('films')
                 .select('title')
-                .select(
-                  pgClient
-                    .embeddedQuery('directors', 'one')
-                    .select('*')
-                    .order([{ column: 'last_name', top: true }]),
-                ),
+                .select(pgClient.embeddedQuery('directors', 'one').select('*'))
+                .order([{ column: 'directors.last_name' }]),
             });
             expect(rows).toEqual([
               { title: 'The Godfather', directors: expect.any(Object) },
@@ -760,12 +756,8 @@ describe('Postgrest Client', () => {
               query: pgClient
                 .query('films')
                 .select('title')
-                .select(
-                  pgClient
-                    .embeddedQuery('directors', 'one')
-                    .select('*')
-                    .order([{ column: 'last_name', top: true, order: 'desc' }]),
-                ),
+                .select(pgClient.embeddedQuery('directors', 'one').select('*'))
+                .order([{ column: 'directors.last_name', order: 'desc' }]),
             });
             expect(rows).toEqual([
               { title: 'The Dark Knight', directors: expect.any(Object) },
@@ -779,30 +771,15 @@ describe('Postgrest Client', () => {
           });
 
           it('secondary', async () => {
-            console.log(
-              pgClient
-                .query('films')
-                .select('title')
-                .select(
-                  pgClient
-                    .embeddedQuery('directors', 'one')
-                    .select('*')
-                    .order([{ column: 'last_name', top: true }]),
-                )
-                .order([{ column: 'year', order: 'desc' }])
-                .toString({ encoded: false }),
-            );
             const { rows } = await pgClient.get({
               query: pgClient
                 .query('films')
                 .select('title')
-                .select(
-                  pgClient
-                    .embeddedQuery('directors', 'one')
-                    .select('*')
-                    .order([{ column: 'last_name', top: true }]),
-                )
-                .order([{ column: 'year', order: 'desc' }]),
+                .select(pgClient.embeddedQuery('directors', 'one').select('*'))
+                .order([
+                  { column: 'directors.last_name' },
+                  { column: 'year', order: 'desc' },
+                ]),
             });
             expect(rows).toEqual([
               { title: 'The Godfather Part II', directors: expect.any(Object) },
@@ -821,12 +798,10 @@ describe('Postgrest Client', () => {
                 .query('films')
                 .select('title')
                 .select([
-                  pgClient
-                    .embeddedQuery('directors', 'one')
-                    .select('*')
-                    .order([{ column: 'last_name', top: true }]),
+                  pgClient.embeddedQuery('directors', 'one').select('*'),
                   { name: 'director' },
-                ]),
+                ])
+                .order([{ column: 'director.last_name' }]),
             });
             expect(rows).toEqual([
               { title: 'The Godfather', director: expect.any(Object) },

--- a/test/postgrest-client.test.ts
+++ b/test/postgrest-client.test.ts
@@ -864,6 +864,17 @@ describe('Postgrest Client', () => {
             phones: [{ country_code: 61, number: '917-929-5745' }],
           });
         });
+
+        it('order', async () => {
+          const { rows } = await pgClient.get({
+            query: pgClient
+              .query('countries')
+              .selectJson<{ lat: number }>(['location->lat', { name: 'lat' }])
+              .order([{ column: 'location->lat', order: 'desc' }]),
+          });
+          const ordered = [...rows].sort((a, b) => b.lat - a.lat);
+          expect(ordered).toEqual(rows);
+        });
       });
 
       describe('composite columns', () => {


### PR DESCRIPTION
Support for top level ordering using dot notation.
https://postgrest.org/en/v12/references/api/resource_embedding.html#top-level-ordering

No interface changes. The only change is supported fields for `column` in `.order([{ column: 'column_name' }])`. Instead of only accepting current table column names, it now accepts embedded fields with dot notation to drill down.

Example:
```ts
const query = pgClient
  .query('films')
  .select('title')
  .select(pgClient.embeddedQuery('directors', 'one').select('*'))
  .order([{ column: 'directors.last_name', order: 'desc' }]);
```

---

#### Alternative considerations

We considered different approaches to implement this and current implementation was more difficult to implement but better for developer experience.

One of the alternatives we considered:
Using more properties for order method parameters to say it's a top level query (`top: true`). Example:
```ts
const query = pgClient
  .query('films')
  .select('title')
  .select(pgClient.embeddedQuery('directors', 'one')
    .select('*')
    .order([{ column: 'last_name', order: 'desc', top: true }])
  );
```

The problem with this approach was with order precedence when top level and root orders are used together. We had problems constructing a query with both of these options `order=id,films(id)` and `order=films(id),id`.
We considered 2 solutions - precedence based on method call order, and one more property for precedence like `weight: number`. Both of these options looked like unintuitive, so instead we ended up with dot notation on root query (implementation in this PR)

---

Note that documentation will be added later after this is released.