### PR TITLE
fix: string | null when JSON type is unknown

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -388,21 +388,68 @@ type VerticalEmbeddedFilterWithModifierReturn<
       : never
     : never;
 
-type E<T> = T extends `${string}->>${infer Col}` ? Col : never;
+/**
+ * Extracts leaf property name from JSON object.
+ *
+ * @typeParam P - path ending with `->>` with optional `->` in between
+ */
+type ExtractLeaf<P> = P extends `${string}->>${infer Col}` ? Col : never;
+
+/**
+ * Follows the path with single and double arrows to find if the object is typed.
+ * It returns `string` if the path is typed, and otherwise `string | null`.
+ *
+ * @typeParam P - path ending with `->>` with optional `->` in between
+ * @typeParam O - object possibly containing the path
+ * @typeParam L - leaf key in recursive calls
+ */
+type ExtractObj<
+  P extends string,
+  O extends Record<string, any>,
+  L extends keyof O = never,
+> = keyof O extends string
+  ? P extends `${infer P}->>${infer LL}`
+    ? P extends `${infer Col}->${infer PP}`
+      ? ExtractObj<PP, O[Col], LL>
+      : keyof O[P] extends string
+        ? string
+        : string | null
+    : P extends `${infer Col}->${infer PP}`
+      ? PP extends `${string}->${string}`
+        ? ExtractObj<PP, O[Col], L>
+        : string
+      : string
+  : string | null;
 
 type CompositeStringFilterReturn<
   DB extends BaseDB,
   TableName extends keyof DB,
   R extends object | '*' | null,
   Selector,
-> =
-  E<Selector> extends never
+> = Selector extends string
+  ? ExtractLeaf<Selector> extends never
     ? never
     : R extends '*'
-      ? DB[TableName]['get'] & { [P in E<Selector>]: string }
+      ? DB[TableName]['get'] & {
+          [P in ExtractLeaf<Selector>]: ExtractObj<
+            Selector,
+            DB[TableName]['get']
+          >;
+        }
       : R extends null
-        ? { [P in E<Selector>]: string }
-        : R & { [P in E<Selector>]: string };
+        ? {
+            [P in ExtractLeaf<Selector>]: ExtractObj<
+              Selector,
+              DB[TableName]['get']
+            >;
+          }
+        : R & {
+            [P in ExtractLeaf<Selector>]: ExtractObj<
+              Selector,
+              DB[TableName]['get']
+            >;
+          }
+  : never;
 
 type CompositeStringFilterWithModifierReturn<
   DB extends BaseDB,
@@ -413,16 +460,35 @@ type CompositeStringFilterWithModifierReturn<
   Selector extends CompositeStringFilterWithModifier<DB, TableName>
     ? R extends '*'
       ? Rename<
-          DB[TableName]['get'] & { [P in E<Selector[0]>]: string },
-          E<Selector[0]>,
+          DB[TableName]['get'] & {
+            [P in ExtractLeaf<Selector[0]>]: ExtractObj<
+              Selector[0],
+              DB[TableName]['get']
+            >;
+          },
+          ExtractLeaf<Selector[0]>,
           Selector[1]
         >
       : R extends null
-        ? Rename<{ [P in E<Selector[0]>]: string }, E<Selector[0]>, Selector[1]>
+        ? Rename<
+            {
+              [P in ExtractLeaf<Selector[0]>]: ExtractObj<
+                Selector[0],
+                DB[TableName]['get']
+              >;
+            },
+            ExtractLeaf<Selector[0]>,
+            Selector[1]
+          >
         : R &
             Rename<
-              { [P in E<Selector[0]>]: string },
-              E<Selector[0]>,
+              {
+                [P in ExtractLeaf<Selector[0]>]: ExtractObj<
+                  Selector[0],
+                  DB[TableName]['get']
+                >;
+              },
+              ExtractLeaf<Selector[0]>,
               Selector[1]
             >
     : never;

--- a/test/postgrest-client/methods/get.test.ts
+++ b/test/postgrest-client/methods/get.test.ts
@@ -687,12 +687,12 @@ describe.each([
           .query('people')
           .eq('id', 1)
           .selectJson<{
-            blood_type: string;
+            blood_type: string | null;
             country_code: number;
           }>(['json_data->blood_type', 'json_data->phones->0->country_code'])
           .single(),
       });
-      assert<Equals<typeof row.blood_type, string>>();
+      assert<Equals<typeof row.blood_type, string | null>>();
       assert<Equals<typeof row.country_code, number>>();
       expect(row.blood_type).toBeTypeOf('string');
       expect(row.country_code).toBeTypeOf('number');
@@ -709,8 +709,8 @@ describe.each([
           ])
           .single(),
       });
-      assert<Equals<typeof row.blood_type, string>>();
-      assert<Equals<typeof row.country_code, string>>();
+      assert<Equals<typeof row.blood_type, string | null>>();
+      assert<Equals<typeof row.country_code, string | null>>();
       expect(row.blood_type).toBeTypeOf('string');
       expect(row.country_code).toBeTypeOf('string');
     });
@@ -770,6 +770,7 @@ describe.each([
           .select(['languages->>0', { name: 'primary_language' }])
           .single(),
       });
+      assert<Equals<typeof row, { primary_language: string | null }>>();
       expect(row).toMatchObject({ primary_language: 'en' });
     });
   });
@@ -783,7 +784,7 @@ describe.each([
           .select(['json_data->>blood_type', { name: 'bloodType' }])
           .single(),
       });
-      assert<Equals<typeof row.bloodType, string>>();
+      assert<Equals<typeof row.bloodType, string | null>>();
       expect(row.bloodType).toBeTypeOf('string');
     });
 
@@ -798,8 +799,8 @@ describe.each([
           ])
           .single(),
       });
-      assert<Equals<typeof row.bloodType, string>>();
-      assert<Equals<typeof row.countryCode, string>>();
+      assert<Equals<typeof row.bloodType, string | null>>();
+      assert<Equals<typeof row.countryCode, string | null>>();
       expect(row.bloodType).toBeTypeOf('string');
       expect(row.countryCode).toBeTypeOf('string');
     });

--- a/test/query/vertical-filtering.test.ts/json-filtering.test.ts
+++ b/test/query/vertical-filtering.test.ts/json-filtering.test.ts
@@ -204,7 +204,13 @@ describe('vertical filtering', () => {
       assert<
         Equals<
           SingleWithId,
-          { rows: { id: number; someVal: string; someOtherVal: string }[] }
+          {
+            rows: {
+              id: number;
+              someVal: string | null;
+              someOtherVal: string | null;
+            }[];
+          }
         >
       >();
       expect(qSingleWithId.toString({ encoded: false })).toBe(
@@ -225,7 +231,13 @@ describe('vertical filtering', () => {
       assert<
         Equals<
           MultiWithId,
-          { rows: { id: number; someVal: string; someOtherVal: string }[] }
+          {
+            rows: {
+              id: number;
+              someVal: string | null;
+              someOtherVal: string | null;
+            }[];
+          }
         >
       >();
       expect(qMultiWithId.toString({ encoded: false })).toBe(


### PR DESCRIPTION
PostgREST client supports typing JSON columns and it returns correct types when JSON column is type.

The problem was when JSON type was unknown (`any`) and there was a JSON selector supposed to return a `string` (ending with `->>`). In that case the type should be `string | null`