### PR TITLE
fix: using less strict type for order column

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -49,16 +49,16 @@ type FilterItemTupleArray<
 > = [Column, (string | number)[], IsNegated];
 
 type ObjPaths<T> = T extends EmptyObject
-  ? never
+  ? string
   : T extends object
     ? {
         [K in keyof T]: K extends string
           ? T[K] extends object
             ? `${K}.${ObjPaths<T[K]>}` | `${K}->${ObjPaths<T[K]>}`
             : K
-          : never;
+          : string;
       }[keyof T]
-    : never;
+    : string;
 
 type Order<QO extends object> = {
   column: ObjPaths<QO>;


### PR DESCRIPTION
It's difficult to infer the column options when constructing a dynamic query.

pseudocode example:
```ts
const myFn = (tableName: string, orderColumn: string) => pgClient
  .query(tableName)
  .order([{ column: orderColumn }])
```