### PR TITLE
test: image versions lock and schema fix

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,19 +4,19 @@
 version: '3.8'
 services:
   client:
-    image: node:20
+    image: node:24
     depends_on:
       - server
     volumes:
       - .:/app
     working_dir: /app
   server:
-    image: postgrest/postgrest
+    image: postgrest/postgrest:v14.4
     environment:
       PGRST_DB_URI: postgres://app_user:password@db:5432/app_db
       PGRST_SERVER_PORT: 9000
       PGRST_DB_ANON_ROLE: anon
-      PGRST_DB_SCHEMAS: 'api, api2'
+      PGRST_DB_SCHEMAS: 'api'
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:9000
       PGRST_OPENAPI-MODE: ignore-privileges
       PGRST_DB_MAX_ROWS: 1000
@@ -24,7 +24,7 @@ services:
       db:
         condition: service_healthy
   db:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_DB: app_db
       POSTGRES_USER: app_user

--- a/test/postgrest-client/methods/get.test.ts
+++ b/test/postgrest-client/methods/get.test.ts
@@ -252,8 +252,9 @@ describe.each([
         status: 404,
         statusText: 'Not Found',
         data: {
-          code: '42P01',
-          message: 'relation "api.non-existing" does not exist',
+          code: 'PGRST205',
+          message:
+            "Could not find the table 'api.non-existing' in the schema cache",
         },
       });
     });


### PR DESCRIPTION
Our tests started failing because we had non-existing schema "api2" in configuration.
Also, due to newer image being pulled one of the tests started failing due to different PostgREST error message.